### PR TITLE
Fix for 2 unrelated issues for video processing 

### DIFF
--- a/include/iarpa_janus.h
+++ b/include/iarpa_janus.h
@@ -427,7 +427,8 @@ typedef struct janus_attributes
                                     \see nouse_mouth_visible. */
     bool indoor; /*!< \brief Image was captured indoors \see \ref indoor. */
 
-    double frame_number; /*!< \brief Frame number or NAN for images. */
+    double frame_number; /*!< \brief Frame number or NAN for images. In the case of videos
+                                     the frame number is a 0-based unsigned integer index. */
 } janus_attributes;
 
 /*!
@@ -549,7 +550,10 @@ typedef enum janus_template_role {
  *       done by the internal algorithm if they wish to extend the single frame
  *       annotation to subsequent frames. If tracking is done, the single frame
  *       ground truth track should be extended with any additional information
- *       so that the calling function can make use of it.
+ *       so that the calling function can make use of it. Note also that the returned
+ *       track may be sparsely populated (i.e it might skip frames). In all cases
+ *       the \ref janus_attributes::frame_number field should accurately represent
+ *       the frame the janus_attributes location information originated from.
  *
  * \param[in,out] associations A vector of associations between a piece of media
  *                             and relevant metadata. All of the associations provided

--- a/include/iarpa_janus.h
+++ b/include/iarpa_janus.h
@@ -114,7 +114,7 @@
 #endif
 
 #define JANUS_VERSION_MAJOR 0
-#define JANUS_VERSION_MINOR 4
+#define JANUS_VERSION_MINOR 5
 #define JANUS_VERSION_PATCH 1 
 
 /*!
@@ -542,16 +542,26 @@ typedef enum janus_template_role {
  * one time and the constructed template is expected to be suitable for
  * verification and search.
  *
- * \param[in] associations A vector of associations between a piece of media
- *                         and relevant metadata. All of the associations provided
- *                         are guaranteed to be of a single subject
+ * \note In the case of an input video it is often the case that a ground truth
+ *       location of a subject of interest is specified only in one frame. This
+ *       is represented in the API as a track with only one entry provided along
+ *       with a media object representing a video. In this case, tracking can be
+ *       done by the internal algorithm if they wish to extend the single frame
+ *       annotation to subsequent frames. If tracking is done, the single frame
+ *       ground truth track should be extended with any additional information
+ *       so that the calling function can make use of it.
+ *
+ * \param[in,out] associations A vector of associations between a piece of media
+ *                             and relevant metadata. All of the associations provided
+ *                             are guaranteed to be of a single subject. This is not const
+ *                             to allow additional tracking if the implementation supports it.
  * \param[in] role An enumeration describing the intended function for the created template.
  *                 Implementors are not required to have different types of templates for any/all
  *                 of the roles specified but can if they choose.
  * \param[out] template_ The template to contain the subject's recognition information.
  * \remark This function is \ref reentrant.
  */
-JANUS_EXPORT janus_error janus_create_template(const std::vector<janus_association> &associations,
+JANUS_EXPORT janus_error janus_create_template(std::vector<janus_association> &associations,
                                                const janus_template_role role,
                                                janus_template &template_);
 

--- a/src/janus_io.cpp
+++ b/src/janus_io.cpp
@@ -263,6 +263,8 @@ struct TemplateIterator
                 double value = attributeValue.empty() ? NAN : atof(attributeValue.c_str());
                 if (header[j] == "FRAME_NUM")
                     attributes.frame_number = value;
+                else if (header[j] == "VIDEO_FILENAME")
+                    filename = attributeValue;
                 else if (header[j] == "FACE_X")
                     attributes.face_x = value;
                 else if (header[j] == "FACE_Y")

--- a/src/janus_io.cpp
+++ b/src/janus_io.cpp
@@ -234,10 +234,6 @@ struct TemplateIterator
         getline(file, line);
         istringstream attributeNames(line);
         string attributeName;
-        getline(attributeNames, attributeName, ','); // TEMPLATE_ID
-        getline(attributeNames, attributeName, ','); // SUBJECT_ID
-        getline(attributeNames, attributeName, ','); // FILE_NAME
-        getline(attributeNames, attributeName, ','); // SIGHTING_ID
         vector<string> header;
         while (getline(attributeNames, attributeName, ','))
             header.push_back(attributeName);
@@ -247,24 +243,23 @@ struct TemplateIterator
             TemplateMetadata tmpl;
 
             istringstream attributeValues(line);
-            string templateID, subjectID, filename, sightingID, attributeValue;
-            getline(attributeValues, templateID, ',');
-            getline(attributeValues, subjectID, ',');
-            getline(attributeValues, filename, ',');
-            getline(attributeValues,  sightingID, ',');
-
-            tmpl.templateID = atoi(templateID.c_str());
-            tmpl.subjectID = atoi(subjectID.c_str());
+            string filename, vfilename, sightingID, attributeValue;
 
             // Construct a track from the metadata
             janus_track track;
             janus_attributes attributes;
             for (int j = 0; getline(attributeValues, attributeValue, ','); j++) {
                 double value = attributeValue.empty() ? NAN : atof(attributeValue.c_str());
-                if (header[j] == "FRAME_NUM")
-                    attributes.frame_number = value;
-                else if (header[j] == "VIDEO_FILENAME")
+                if (header[j] == "TEMPLATE_ID")
+                    tmpl.templateID = atoi(attributeValue.c_str());
+                else if (header[j] == "SUBJECT_ID")
+                    tmpl.subjectID = atoi(attributeValue.c_str());
+                else if (header[j] == "FILENAME")
                     filename = attributeValue;
+                else if (header[j] == "SIGHTING_ID")
+                    sightingID = attributeValue;
+                else if (header[j] == "VIDEO_FILENAME")
+                    vfilename = attributeValue;
                 else if (header[j] == "FACE_X")
                     attributes.face_x = value;
                 else if (header[j] == "FACE_Y")
@@ -301,9 +296,14 @@ struct TemplateIterator
                     track.age = value;
                 else if (header[j] == "SKIN_TONE")
                     track.skin_tone = value;
+                else if (header[j] == "FRAME_NUM")
+                    attributes.frame_number = value;
             }
             track.track.push_back(attributes);
 
+            // prefer video filename
+            if (!vfilename.empty()) 
+                filename = vfilename;
             tmpl.metadata.insert(make_pair(atoi(sightingID.c_str()), make_pair(vector<string>{filename}, track)));
 
             if (!templates.empty() && templates.back().templateID == tmpl.templateID) {


### PR DESCRIPTION
1. In the 1N video protocol the video filename wasn't being set properly. This fixes that by forcing the media filename to mirror VIDEO_FILENAME if that header is found in the protocol csv.

2. In the 1N video protocol ground truth location information is provided for the first frame in which a subject of interest appears to inform implementors who they should be tracking. In the current API this information is passed as const list of janus_associations. This change makes that list non-const so that additional any bounding boxes inferred by a tracking algorithm can be added to the track and made available to the calling application.

@nxwhite-str @carlosdcastillo @stephenrawls could you all review at your convenience?